### PR TITLE
Justify paragraphs

### DIFF
--- a/main.css
+++ b/main.css
@@ -61,6 +61,7 @@ h3.time .period {
 
 .description p {
   margin-bottom: .4em;
+  text-align: justify;
 }
 
 .description p:last-of-type {


### PR DESCRIPTION
This change will guarantee all description paragraphs will be justified by default.

We could also change this to be the whole text, but I think scoping these changes to just `.description` should give you a little more control of the styles.